### PR TITLE
Factory Method for transcriber initialization

### DIFF
--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -17,8 +17,6 @@ std::vector<float> pcm32_input;
 std::condition_variable bufferCV;
 std::mutex bufferMutex;
 std::string transcribedText = "";
-std::string MODEL_PATH;
-Audio* audio = nullptr;
 Transcriber* transcriber = nullptr;
 
 

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -35,7 +35,6 @@ extern std::queue<std::vector<float>> pcm32_bufferQueue;
 extern std::vector<float> pcm32_input;
 extern std::condition_variable bufferCV;
 extern std::mutex bufferMutex;
-extern Audio* audio;
 extern Transcriber* transcriber;
 
 extern std::string transcribedText;
@@ -46,7 +45,6 @@ extern raylib::Font raygui_font;
 extern raylib::Font m_font_title;
 
 const std::string m_font_path = "../assets/Fonts/monogram.ttf";
-extern std::string MODEL_PATH;
 
 // CallBack Function for PortAudio
 extern int MyRealTimeCallback(const void* inputBuffer, void* outputBuffer,

--- a/src/MainWindowGUI.cpp
+++ b/src/MainWindowGUI.cpp
@@ -121,15 +121,15 @@ void MainWindowGUI::HandleEvents()
 		if (result == NFD_OKAY)
 		{
 			modelTextBox.inputText = outPath;
-			MODEL_PATH = outPath;
 			
 			if(transcriber != nullptr)
 				delete transcriber;
 				
-			if(audio == nullptr)
-				audio = new Audio();
-
-			transcriber = new Transcriber(*audio);
+			transcriber = Transcriber::Create(outPath);
+			// TODO : Handle invalid input
+			if(transcriber == nullptr){
+				std::cout << "Transcriber initialization failed. Make sure path is correct." << std::endl;
+			}
 		}
 		else if (result == NFD_CANCEL)
 		{
@@ -184,5 +184,6 @@ void MainWindowGUI::HandleEvents()
 void MainWindowGUI::ShutDown()
 {
 	m_font.Unload();
+	delete transcriber;
 	delete window;
 }

--- a/src/STTWindowGUI.cpp
+++ b/src/STTWindowGUI.cpp
@@ -45,7 +45,7 @@ void STTWindowGUI::HandleEvents()
 		// only start the stream once
 		if (isInitialClick)
 		{
-			audio->StartStream(RealTime);
+			transcriber->BeginStreaming();
 			isInitialClick = false;
 		}
 

--- a/src/Transcriber.h
+++ b/src/Transcriber.h
@@ -22,22 +22,24 @@ struct transcribed_msg {
 class Transcriber
 {
 public:
-	Transcriber(Audio& aud);
-
 	void AddAudioData(const std::vector<float>& new_data);
 	std::vector<transcribed_msg> GetTranscribed();
 	bool GenerateKaraoke(const char* inputPath, const char* outputDir);
 	bool BurnInSubtitles(const char* inputPath, const char* outputDir);
+	void BeginStreaming();
 
 	~Transcriber();
 
+	// Factory method
+	static Transcriber* Create(std::string modelPath);
+
 private:
-	Audio& audio;
+	Audio audio;
+	Transcriber(struct whisper_context* stt_ctx, struct whisper_context* karaoke_ctx, struct whisper_context* subtitles_ctx);
 
 	struct whisper_context* ctx;
 	struct whisper_context* karaoke_ctx;
 	struct whisper_context* subtitles_ctx;
-
 
 	std::atomic<bool> is_running;
 	std::vector<float> s_queued_pcmf32;


### PR DESCRIPTION
Now handles invalid model paths. Also moved audio object totally inside the transcriber. 

To fix: App crashes on attempt to change model once it is initialized.